### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Key benefits of using the Composable Commerce Postman collections:
 * No coding is required, and can be used as soon as you have created a Project.
 * Easily explore all the API endpoints and achieve a holistic view of how the platform and other services operate.
 
-[Get Started here](GettingStarted.md) with Composable Commerce Postman collections.
+[Get Started here](GettingStarted.md) with the Composable Commerce Postman collections.
 
 ## Further documentation
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Key benefits of using the Composable Commerce Postman collections:
 
 ## Further documentation
 
-To learn more about using Composable Commerce APIs and to find complete platform documentation, please visit https://docs.commercetools.com/
+To learn more about using Composable Commerce APIs and to find complete API documentation, please visit https://docs.commercetools.com/
 
 ## Postman collections
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# commercetools Postman collections
+# Composable Commerce Postman collections
 
-This repository contains Postman collections for the commercetools APIs.
+This repository contains Postman collections for Composable Commerce HTTP APIs.
 
 ## How to use Postman collections?
 
-Postman collections help you explore commercetools APIs with a setup time of minutes. You can theoretically run the whole commerce journey from creating customers and products, to creating orders where these customers purchase the products.
+Postman collections help you explore Composable Commerce HTTP APIs with a setup time of minutes. You can theoretically run the whole commerce journey from creating customers and products, to creating orders where these customers purchase the products.
 
-Key benefits of using Postman collections of commercetools APIs:
+Key benefits of using Postman collections of Composable Commerce APIs:
 * Works with minimum technical knowledge.
-* No coding is required, and can be used as soon as you have created a commercetools project.
+* No coding is required, and can be used as soon as you have created a Project.
 * Easily explore all the API endpoints and achieve a holistic view of how the platform and other services operate.
 
-[Get Started here](GettingStarted.md) with commercetools Postman collections.
+[Get Started here](GettingStarted.md) with Composable Commerce Postman collections.
 
 ## Further documentation
 
-To learn more about using commercetools APIs and to find complete platform documentation, please visit https://docs.commercetools.com/
+To learn more about using Composable Commerce APIs and to find complete platform documentation, please visit https://docs.commercetools.com/
 
-## Postman collections 
+## Postman collections
 
 * [API](api/)
 * [Import](import/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Postman collections for Composable Commerce HTTP APIs.
 
 Postman collections help you explore Composable Commerce HTTP APIs with a setup time of minutes. You can theoretically run the whole commerce journey from creating customers and products, to creating orders where these customers purchase the products.
 
-Key benefits of using Postman collections of Composable Commerce APIs:
+Key benefits of using the Composable Commerce Postman collections:
 * Works with minimum technical knowledge.
 * No coding is required, and can be used as soon as you have created a Project.
 * Easily explore all the API endpoints and achieve a holistic view of how the platform and other services operate.


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests, as this is out of scope.